### PR TITLE
Quickfixes after new delivery date plugins release

### DIFF
--- a/wp-content/plugins/00-panier-quebecois/includes/pq-checkout.php
+++ b/wp-content/plugins/00-panier-quebecois/includes/pq-checkout.php
@@ -39,8 +39,11 @@ add_filter( 'wc_od_get_time_frames_choices', 'pq_default_delivery_time_frame', 1
 
 function pq_default_delivery_time_frame($choices, $time_frames, $context) {
 
-  $key_to_remove = array_search('Choose a time frame', $choices, true);
-  unset($choices[$key_to_remove]);
+  foreach ( $choices as $key => $choice ) {
+    if ( strpos($choice, 'Choose a time frame') !== false ) {
+      unset($choices[$key]);
+    }
+  }
   
   return $choices;
 }


### PR DESCRIPTION
- Pickup opening hours for pickup shown at checkout could be wrong after 3:30pm the day before
- Delivery time was not chosen by default in english version